### PR TITLE
Upgraded gogs to received the :host it needs to call

### DIFF
--- a/lib/megam/gogs.rb
+++ b/lib/megam/gogs.rb
@@ -1,185 +1,136 @@
-require "time"
-require "uri"
-require "zlib"
+require 'time'
+require 'uri'
+require 'zlib'
 require 'openssl'
 require 'net/http'
 require 'excon'
 require 'base64'
 require 'yaml'
 
-__LIB_DIR__ = File.expand_path(File.join(File.dirname(__FILE__), ".."))
-unless $LOAD_PATH.include?(__LIB_DIR__)
-$LOAD_PATH.unshift(__LIB_DIR__)
-end
+__LIB_DIR__ = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+$LOAD_PATH.unshift(__LIB_DIR__) unless $LOAD_PATH.include?(__LIB_DIR__)
 
-require "megam/gogs/version"
-require "megam/gogs/accounts"
-require "megam/gogs/dumpout"
-require "megam/gogs/errors"
-require "megam/gogs/repos"
-require "megam/gogs/tokens"
+require 'megam/gogs/version'
+require 'megam/gogs/accounts'
+require 'megam/gogs/dumpout'
+require 'megam/gogs/errors'
+require 'megam/gogs/repos'
+require 'megam/gogs/tokens'
 
-require "megam/core/gogs_repo"
-require "megam/core/gogs_account"
-require "megam/core/gogs_tokens"
-
+require 'megam/core/gogs_repo'
+require 'megam/core/gogs_account'
+require 'megam/core/gogs_tokens'
 
 module Megam
   class Gogs
-
-   AUTH_PREFIX = 'Authorization'
+    AUTH_PREFIX = 'Authorization'
     HEADERS = {
       'Accept' => 'application/json',
       'Accept-Encoding' => 'gzip',
       'User-Agent' => "megam-gogs/#{Megam::Gogs::VERSION}",
       'X-Ruby-Version' => RUBY_VERSION,
       'X-Ruby-Platform' => RUBY_PLATFORM
-
     }
-    
-    if File.exist?("#{ENV['MEGAM_HOME']}/nilavu.yml")
-      common = YAML.load_file("#{ENV['MEGAM_HOME']}/nilavu.yml")                  #COMMON YML
-      puts "=> Loaded #{ENV['MEGAM_HOME']}/nilavu.yml"
-    else
-      puts "=> Warning ! MEGAM_HOME environment variable not set."
-      common={"api" => {}, "storage" => {}, "varai" => {}, "auth" => {}, "monitor" => {}, "gogs" => {'host' => "", 'port' => ""}}
-    end
-
-   gogs_host     = "#{common['gogs']['host']}" || ENV['GOGS_HOST']
-   gogs_port     = "#{common['gogs']['port']}" || ENV['GOGS_PORT']  
 
     OPTIONS = {
-      :headers => {},
-      :host => gogs_host,
-      :port => gogs_port,
-      :nonblock => false,
-      :scheme => 'http'
+      headers: {},
+      host: "localhost",
+      port: "6001",
+      nonblock: false,
+      scheme: 'http'
     }
 
-    API_REST = "/api/v1"
-
+    API_REST = '/api/v1'
 
     def text
       @text ||= Megam::Dumpout.new(STDOUT, STDERR, STDIN)
     end
 
-    def last_response
-      @last_response
-    end
+    attr_reader :last_response
 
     # It is assumed that every API call will NOT use an API_KEY/email.
-    def initialize(options={})
+    def initialize(options = {})
       @options = OPTIONS.merge(options)
     end
 
-def request(params,&block)
-  #just_color_debug("#{@options[:path]}")
-  start = Time.now
+    def request(params, &block)
+      start = Time.now
 
-  dummy_params =  {
-  :expects  => params[:expects],
-  :method   => params[:method],
-  :body     => params[:body]
-}
+      dummy_params =  {
+        expects: params[:expects],
+        method: params[:method],
+        body: params[:body]
+      }
 
-
-  text.msg "#{text.color("START", :cyan, :bold)}"
-  params.each do |pkey, pvalue|
-    text.msg("> #{pkey}: #{pvalue}")
-  end
-
-if params[:token].nil?
-
-
-  @uname = params[:username]
-  @pass = params[:password]
-  @cred = "#{@uname}:#{@pass}"
-  @final_cred64 = Base64.encode64(@cred)
-
-  @final_hash = { :creds => "Basic #{@final_cred64}" }
-
-  response = connection_repo.request(dummy_params, &block)
-
-  puts response.inspect
-  text.msg("END(#{(Time.now - start).to_s}s)")
-  # reset (non-persistent) connection
-  #@connection_repo.reset
-
-else
-
-  @tokens = params[:token]
-  @final_token = { :token => "token #{@tokens}"}
-  response = connection_token.request(dummy_params, &block)
-
-  puts response.inspect
-  text.msg("END(#{(Time.now - start).to_s}s)")
-  # reset (non-persistent) connection
-  #@connection_token.reset
-end
-
-  response
-
-end
-
-private
-
-#Make a lazy connection.
-def connection_repo
-  @options[:path] =API_REST + @options[:path]
-  #headers_hash = encode_header(@options)
-
-  @options[:headers] = HEADERS.merge({
-    AUTH_PREFIX => @final_hash[:creds],
-
-    }).merge(@options[:headers])
-
-
-
-  puts @options[:headers]
-
-
-    text.msg("HTTP Request Data:")
-    text.msg("> HTTP #{@options[:scheme]}://#{@options[:host]}")
-    @options.each do |key, value|
-      text.msg("> #{key}: #{value}")
-    end
-    text.msg("End HTTP Request Data.")
-    if @options[:scheme] == "https"
-      @connection = Excon.new("#{@options[:scheme]}://#{@options[:host]}",@options)
-    else
-      Excon.defaults[:ssl_verify_peer] = false
-      @connection = Excon.new("#{@options[:scheme]}://#{@options[:host]}:6001",@options)
-    end
-    @connection
-  end
-
-
-  def connection_token
-    @options[:path] =API_REST + @options[:path]
-    #headers_hash = encode_header(@options)
-
-    @options[:headers] = HEADERS.merge({
-      AUTH_PREFIX => @final_token[:token],
-
-      }).merge(@options[:headers])
-
-        puts @options[:headers]
-
-
-        text.msg("HTTP Request Data:")
-        text.msg("> HTTP #{@options[:scheme]}://#{@options[:host]}")
-        @options.each do |key, value|
-          text.msg("> #{key}: #{value}")
-        end
-        text.msg("End HTTP Request Data.")
-        if @options[:scheme] == "https"
-          @connection = Excon.new("#{@options[:scheme]}://#{@options[:host]}",@options)
-        else
-          Excon.defaults[:ssl_verify_peer] = false
-          @connection = Excon.new("#{@options[:scheme]}://#{@options[:host]}:6001",@options)
-        end
-        @connection
+      text.msg "#{text.color('START', :cyan, :bold)}"
+      params.each do |pkey, pvalue|
+        text.msg("> #{pkey}: #{pvalue}")
       end
 
+      if params[:token].nil?
+        @uname = params[:username]
+        @pass = params[:password]
+        @cred = "#{@uname}:#{@pass}"
+        @final_cred64 = Base64.encode64(@cred)
+
+        @final_hash = { creds: "Basic #{@final_cred64}" }
+
+        response = connection_repo.request(dummy_params, &block)
+        text.msg("END(#{(Time.now - start)}s)")
+      else
+
+        @tokens = params[:token]
+        @final_token = { token: "token #{@tokens}" }
+        response = connection_token.request(dummy_params, &block)
+
+        puts response.inspect
+        text.msg("END(#{(Time.now - start)}s)")
+        # reset (non-persistent) connection
+        # @connection_token.reset
+      end
+
+      response
+    end
+
+    private
+
+    # Make a lazy connection.
+    def connection_repo
+      @options[:path] = API_REST + @options[:path]
+
+      @options[:headers] = HEADERS.merge(AUTH_PREFIX => @final_hash[:creds]).merge(@options[:headers])
+
+      text.msg('HTTP Request Data:')
+      text.msg("> HTTP #{@options[:scheme]}://#{@options[:host]}")
+      @options.each do |key, value|
+        text.msg("> #{key}: #{value}")
+      end
+      text.msg('End HTTP Request Data.')
+      if @options[:scheme] == 'https'
+        @connection = Excon.new("#{@options[:scheme]}://#{@options[:host]}", @options)
+      else
+        Excon.defaults[:ssl_verify_peer] = false
+        @connection = Excon.new("#{@options[:scheme]}://#{@options[:host]}:6001", @options)
+      end
+      @connection
+      end
+
+    def connection_token
+      @options[:path] = API_REST + @options[:path]
+      @options[:headers] = HEADERS.merge(AUTH_PREFIX => @final_token[:token]).merge(@options[:headers])
+      text.msg('HTTP Request Data:')
+      text.msg("> HTTP #{@options[:scheme]}://#{@options[:host]}")
+      @options.each do |key, value|
+        text.msg("> #{key}: #{value}")
+      end
+      text.msg('End HTTP Request Data.')
+      if @options[:scheme] == 'https'
+        @connection = Excon.new("#{@options[:scheme]}://#{@options[:host]}", @options)
+      else
+        Excon.defaults[:ssl_verify_peer] = false
+        @connection = Excon.new("#{@options[:scheme]}://#{@options[:host]}:6001", @options)
+      end
+      @connection
+      end
   end
 end

--- a/lib/megam/gogs/version.rb
+++ b/lib/megam/gogs/version.rb
@@ -1,5 +1,5 @@
 module Megam
   class Gogs
-    VERSION = "0.7.0"
+    VERSION = "0.8.0"
   end
 end

--- a/megam_gogs.gemspec
+++ b/megam_gogs.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.name        = "megam_gogs"
   s.version     = Megam::Gogs::VERSION
   s.authors     = ["Raj Thilak,Kishorekumar Neelamegam, Thomas Alrin, Yeshwanth Kumar"]
-  s.email       = ["rajthilak@megam.co.in","nkishore@megam.co.in","alrin@megam.co.in, getyesh@megam.co.in"]
+  s.email       = ["rajthilak@megam.io","nkishore@megam.io","alrin@megam.io, getyesh@megam.io"]
   s.homepage    = "http://github.com/megamsys/megam_gogs.rb"
   s.license = "Apache V2"
   sextra_rdoc_files = ["README.md", "LICENSE" ]
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,fea,tures}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.add_runtime_dependency 'highline', '~> 1.6'
+  s.add_runtime_dependency 'highline', '~> 1.7.2'
   s.add_runtime_dependency 'nokogiri', '~> 1.6'
-  s.add_development_dependency 'minitest', '~> 5.2'
-  s.add_development_dependency 'rake', '~> 10.1'
+  s.add_development_dependency 'minitest', '~> 5.6'
+  s.add_development_dependency 'rake', '~> 10.4'
 end

--- a/megam_gogs.gemspec
+++ b/megam_gogs.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,fea,tures}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.add_runtime_dependency 'highline', '~> 1.7.2'
+  s.add_runtime_dependency 'highline', '~> 1.7'
   s.add_runtime_dependency 'nokogiri', '~> 1.6'
   s.add_development_dependency 'minitest', '~> 5.6'
   s.add_development_dependency 'rake', '~> 10.4'


### PR DESCRIPTION
`:host` was pulled from the nilavu.yml file. This is bad and hence removed it. Any client which wants to use megam_gogs.rb will pass the `:host` it will connect to.
